### PR TITLE
Separate dependencies processing into own class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "theseer/autoload": "^1.21"
     },
     "autoload": {
-        "psr-4": {
-            "Fedora\\Autoloader\\": "src"
-        }
+        "files": [
+            "src/autoload.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
@@ -40,7 +40,7 @@
         }
     },
     "scripts": {
-        "cs": "php-cs-fixer fix || :",
+        "cs": "php-cs-fixer fix",
         "phpdoc": "phpdoc -d src -i src/autoload.php -t phpdoc",
         "test": "phpunit"
     }

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -203,37 +203,6 @@ class Autoload
     }
 
     /**
-     * Requires other autoloader dependency files.
-     *
-     * Loops through all $dependencies.  If a dependency is required,
-     * it is always loaded.  If a dependency  is not required, it is
-     * only loaded if the dependency autoloader file exists.
-     *
-     * Example:
-     *
-     * ```php
-     * \Fedora\Autoloader::dependencies(array(
-     *     // Required dependency so always load.
-     *     '/usr/share/php/Foo/autoload.php' => true,
-     *     // Optional dependency so only load if it exists.
-     *     '/usr/share/php/Bar/autoload.php' => false,
-     * ));
-     * ```
-     *
-     * @param array $dependencies Autoloader dependency files.
-     *                            Keys: Dependency autoloader files.
-     *                            Values: Whether dependcy autoloader file is required or not.
-     */
-    public static function dependencies(array $dependencies)
-    {
-        foreach ($dependencies as $dependency => $required) {
-            if ($required || file_exists($dependency)) {
-                requireFile($dependency);
-            }
-        }
-    }
-
-    /**
      * Loads a class' file.
      *
      * This is the self function registered as an autoload handler.

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -304,19 +304,3 @@ class Autoload
         }
     }
 }
-
-/**
- *
- */
-function requireFile($file)
-{
-    require_once $file;
-}
-
-/**
- *
- */
-function includeFile($file)
-{
-    include_once $file;
-}

--- a/src/Dependencies.php
+++ b/src/Dependencies.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * This file is part of the Fedora Autoloader package.
+ *
+ * (c) Shawn Iwinski <shawn@iwin.ski> and Remi Collet <remi@fedoraproject.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fedora\Autoloader;
+
+class Dependencies
+{
+    /**
+     * Static functions only.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Processes dependencies to require/load.
+     *
+     * Loops through all $dependencies:
+     * - If dependency is not an array:
+     *     - If dependency is required, it is always required/loaded.
+     *     - If dependency is not required, it is only required/loaded if it
+     *       exists.
+     * - If dependency is an array, loops through all items until the first
+     *   item that exists is found and then it is required/loaded.  If no item
+     *   is found and the dependency is required, the last item will be
+     *   required/loaded (causing an error).
+     *
+     * Example 1 (required):
+     *
+     * ```php
+     * process(array(
+     *     '/usr/share/php/Foo/autoload.php',
+     *     '/usr/share/php/Bar/autoload.php',
+     * ), true);
+     * ```
+     *
+     * `/usr/share/php/Foo/autoload.php` and `/usr/share/php/Bar/autoload.php`
+     * are always required/loaded.
+     *
+     * Example 2 (optional):
+     *
+     * ```php
+     * process(array(
+     *     '/usr/share/php/Foo/autoload.php',
+     *     '/usr/share/php/Bar/autoload.php',
+     * ), false);
+     * ```
+     *
+     * `/usr/share/php/Foo/autoload.php` is only required/loaded if it exists.
+     * `/usr/share/php/Bar/autoload.php` is only required/loaded if it exists.
+     *
+     * Example 3 (required, first exists):
+     *
+     * ```php
+     * process(array(
+     *     array(
+     *         '/usr/share/php/Foo/autoload.php',
+     *         '/usr/share/php/Bar/autoload.php',
+     *     )
+     * ), true);
+     * ```
+     *
+     * - If `/usr/share/php/Foo/autoload.php` exists, it is required/loaded and
+     *   `/usr/share/php/Bar/autoload.php` is skipped.
+     * - If `/usr/share/php/Foo/autoload.php` does not exist, it is skipped. If
+     *   `/usr/share/php/Bar/autoload.php` exists, it is required/loaded.
+     * - If neither `/usr/share/php/Foo/autoload.php` nor `/usr/share/php/Bar/autoload.php`
+     *   exist, `/usr/share/php/Bar/autoload.php` is required/loaded and an
+     *   error occurs.
+     *
+     * Example 4 (optional, first exists):
+     *
+     * ```php
+     * process(array(
+     *     array(
+     *         '/usr/share/php/Foo/autoload.php',
+     *         '/usr/share/php/Bar/autoload.php',
+     *     )
+     * ), true);
+     * ```
+     *
+     * - If `/usr/share/php/Foo/autoload.php` exists, it is required/loaded and
+     *   `/usr/share/php/Bar/autoload.php` is skipped.
+     * - If `/usr/share/php/Foo/autoload.php` does not exist, it is skipped. If
+     *   `/usr/share/php/Bar/autoload.php` exists, it is required/loaded.
+     * - If neither `/usr/share/php/Foo/autoload.php` nor `/usr/share/php/Bar/autoload.php`
+     *   exist, nothing occurs.
+     *
+     * @param array $dependencies Dependencies
+     * @param bool  $required     Whether dependencies are required or not.
+     */
+    protected static function process(array $dependencies, $required)
+    {
+        foreach ($dependencies as $dependency) {
+            if (is_array($dependency)) {
+                $dependencyToLoad = null;
+
+                foreach ($dependency as $firstExistsDependency) {
+                    if (file_exists($firstExistsDependency)) {
+                        $dependencyToLoad = $firstExistsDependency;
+                        break;
+                    }
+                }
+
+                if ($required || isset($dependencyToLoad)) {
+                    if (!isset($dependencyToLoad)) {
+                        $dependencyToLoad = end($dependency);
+                    }
+
+                    requireFile($dependencyToLoad);
+                }
+            } elseif ($required || file_exists($dependency)) {
+                requireFile($dependency);
+            }
+        }
+    }
+
+    /**
+     * Requires dependency files.
+     *
+     * Calls `process($requiredDependencies, true)`.
+     *
+     * @param array $requiredDependencies Required dependencies.
+     *
+     * @see process()
+     */
+    public static function required(array $requiredDependencies)
+    {
+        static::process($requiredDependencies, true);
+    }
+
+    /**
+     * Optionally requires other dependency files if they exist.
+     *
+     * Calls `process($optionalDependencies, false)`.
+     *
+     * @param array $optionalDependencies Optional dependencies.
+     *
+     * @see process()
+     */
+    public static function optional(array $optionalDependencies)
+    {
+        static::process($optionalDependencies, false);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,7 +10,14 @@
 namespace Fedora\Autoloader;
 
 /**
+ * Scope isolated require.
  *
+ * Prevents access to a class' $this/self from required files.
+ *
+ * Originally taken from
+ * {@link https://github.com/composer/composer/blob/master/src/Composer/Autoload/ClassLoader.php Composer/Autoload/ClassLoader::includeFile()}.
+ *
+ * @param string $file File to `require_once`.
  */
 function requireFile($file)
 {
@@ -18,7 +25,14 @@ function requireFile($file)
 }
 
 /**
+ * Scope isolated include.
  *
+ * Prevents access to a class' $this/self from included files.
+ *
+ * Originally taken from
+ * {@link https://github.com/composer/composer/blob/master/src/Composer/Autoload/ClassLoader.php Composer/Autoload/ClassLoader::includeFile()}.
+ *
+ * @param string $file File to `include_once`.
  */
 function includeFile($file)
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,7 +7,20 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-require_once __DIR__.'/Autoload.php';
-require_once __DIR__.'/functions.php';
+namespace Fedora\Autoloader;
 
-\Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__);
+/**
+ *
+ */
+function requireFile($file)
+{
+    require_once $file;
+}
+
+/**
+ *
+ */
+function includeFile($file)
+{
+    include_once $file;
+}

--- a/tests/DependenciesTest.php
+++ b/tests/DependenciesTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of the Fedora Autoloader package.
+ *
+ * (c) Shawn Iwinski <shawn@iwin.ski> and Remi Collet <remi@fedoraproject.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fedora\Autoloader\Test;
+
+use Fedora\Autoloader\Dependencies;
+
+class DependenciesTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRequiredExists()
+    {
+        $this->assertFalse(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+
+        Dependencies::required(array(
+            __DIR__.'/fixtures/Foo/Bar.php',
+            __DIR__.'/fixtures/Foo/Bar/Baz.php',
+        ));
+
+        $this->assertTrue(class_exists('Foo\\Bar'));
+        $this->assertTrue(class_exists('Foo\\Bar\\Baz'));
+    }
+
+    public function testRequiredNotExists()
+    {
+        $this->markTestSkipped('Skipping until we can get this test to pass');
+        //Dependencies::required(array(__DIR__.'/fixtures/DoesNotExist.php'));
+    }
+
+    public function testRequiredFirstExists()
+    {
+        $this->assertFalse(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+
+        Dependencies::required(array(
+            array(
+                __DIR__.'/fixtures/DoesNotExist.php',
+                __DIR__.'/fixtures/Foo/Bar.php',
+                __DIR__.'/fixtures/Foo/Bar/Baz.php',
+            ),
+        ));
+
+        $this->assertTrue(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+    }
+
+    public function testOptionalExists()
+    {
+        $this->assertFalse(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+
+        Dependencies::optional(array(
+            __DIR__.'/fixtures/DoesNotExist.php',
+            __DIR__.'/fixtures/Foo/Bar.php',
+            __DIR__.'/fixtures/Foo/Bar/Baz.php',
+        ));
+
+        $this->assertTrue(class_exists('Foo\\Bar'));
+        $this->assertTrue(class_exists('Foo\\Bar\\Baz'));
+    }
+
+    public function testOptionalNotExists()
+    {
+        Dependencies::optional(array(__DIR__.'/fixtures/DoesNotExist.php'));
+    }
+
+    public function testOptionalFirstExists()
+    {
+        $this->assertFalse(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+
+        Dependencies::optional(array(
+            array(
+                __DIR__.'/fixtures/DoesNotExist.php',
+                __DIR__.'/fixtures/Foo/Bar.php',
+                __DIR__.'/fixtures/Foo/Bar/Baz.php',
+            ),
+        ));
+
+        $this->assertTrue(class_exists('Foo\\Bar'));
+        $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
+    }
+}

--- a/tests/fixtures/Foo/Bar/Baz.php
+++ b/tests/fixtures/Foo/Bar/Baz.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Foo\Bar;
+
+class Baz
+{
+}


### PR DESCRIPTION
@remicollet what do you think about this?  I wanted to have the "first exists" logic but I thought the main `Autoload` class was getting too long/complicated and since we switched to the `Fedora\Autoloader\` namespace, I decided to split out the processing of dependencies into its' own file.
