### PR TITLE
Refactor autoload.php with a constant conditional

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -7,9 +7,16 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-if (!class_exists('Fedora\\Autoloader\\Autoload', false)) {
-    require_once __DIR__.'/Autoload.php';
-    require_once __DIR__.'/functions.php';
-}
+if (!defined('FEDORA_AUTOLOADER')) {
+    if (!class_exists('Fedora\\Autoloader\\Autoload', false)) {
+        require_once __DIR__.'/Autoload.php';
+    }
 
-\Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__);
+    if (!function_exists('Fedora\\Autoloader\\requireFile')) {
+        require_once __DIR__.'/functions.php';
+    }
+
+    \Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__);
+
+    define('FEDORA_AUTOLOADER', true);
+}


### PR DESCRIPTION
This is up for debate.

Something didn't feel right about the following to me:

``` php
if (!class_exists('Fedora\\Autoloader\\Autoload', false)) {
    require_once '/usr/share/php/Fedora/Autoloader/autoload.php';
}
```

This change allows `autoload.php` to be **fully loaded** (even if class `Fedora\\Autoloader\\Autoload` happened to be loaded already) successfully multiple times without any PHP errors.  The constant is just for conditionals and to prevent multiple `addPsr4()` calls.  If we wanted to put the loading conditional in other files, we could use:

``` php
if (!defined('FEDORA_AUTOLOADER')) {
    require_once '/usr/share/php/Fedora/Autoloader/autoload.php';
}
```
