### PR TITLE
Remove self-autoload constant

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -7,16 +7,12 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-if (!defined('FEDORA_AUTOLOADER')) {
-    if (!class_exists('Fedora\\Autoloader\\Autoload', false)) {
-        require_once __DIR__.'/Autoload.php';
-    }
-
-    if (!function_exists('Fedora\\Autoloader\\requireFile')) {
-        require_once __DIR__.'/functions.php';
-    }
-
-    \Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__);
-
-    define('FEDORA_AUTOLOADER', true);
+if (!class_exists('Fedora\\Autoloader\\Autoload', false)) {
+    require_once __DIR__.'/Autoload.php';
 }
+
+if (!function_exists('Fedora\\Autoloader\\requireFile')) {
+    require_once __DIR__.'/functions.php';
+}
+
+\Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__, true);

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -15,4 +15,4 @@ if (!function_exists('Fedora\\Autoloader\\requireFile')) {
     require_once __DIR__.'/functions.php';
 }
 
-\Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__, true);
+\Fedora\Autoloader\Autoload::addPsr4('Fedora\\Autoloader\\', __DIR__);


### PR DESCRIPTION
Besides removing the constant, `addPsr4()` is also called with `$prepend = true`.

Validated on all Fedora/EPEL dists' Koji scratch builds.
