### PR TITLE
allow non full patch in dependencies list, rely on include_path

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -10,6 +10,29 @@
 namespace Fedora\Autoloader;
 
 /**
+ * Check if given path is a full or relative path
+ *
+ * @param string $path to check
+ *
+ * @return boolean
+ */
+function isFullPath($path)
+{
+    if (DIRECTORY_SEPARATOR == '/') {
+        /* Unix/Linux */
+        return ($path[0] == '/');
+    }
+    /* Windows */
+    if (ctype_alpha($path[0]) && $path[1]==':') {
+        return true; // Drive
+    }
+    if (($path[0] == '/' && $path[1] == '/') || ($path[0] == '\\' && $path[1] == '\\')) {
+        return true; // UNC
+    }
+    return false;
+}
+
+/**
  * Scope isolated require.
  *
  * Prevents access to a class' $this/self from required files.
@@ -23,6 +46,12 @@ namespace Fedora\Autoloader;
  */
 function requireFile($file)
 {
+    if (!isFullPath($file)) {
+        // Search for relative path in the defined include_path
+        if ($path = stream_resolve_include_path($file)) {
+            $file = $path;
+        }
+    }
     if (is_file($file) && is_readable($file)) {
         require_once $file;
     } else {

--- a/tests/DependenciesTest.php
+++ b/tests/DependenciesTest.php
@@ -127,4 +127,51 @@ class DependenciesTest extends TestCase
         $this->assertTrue(class_exists('Foo\\Bar'));
         $this->assertFalse(class_exists('Foo\\Bar\\Baz'));
     }
+
+    public function testIncludePathRequired()
+    {
+        // Check if PEAR is installed
+        $pear = false;
+        foreach (explode(PATH_SEPARATOR, get_include_path()) as $p) {
+            if (file_exists("$p/PEAR.php")) {
+                $pear = true;
+                break;
+            }
+        }
+        if (!$pear) {
+            $this->markTestSkipped('PEAR not found in include_path');
+        }
+        $this->assertFalse(class_exists('PEAR'));
+
+        Dependencies::required(array(
+            'PEAR.php',
+        ));
+
+        $this->assertTrue(class_exists('PEAR'));
+    }
+
+    /**
+     * @depends testIncludePathRequired
+     **/
+    public function testIncludePathOptional()
+    {
+        $this->assertFalse(class_exists('PEAR'));
+
+        Dependencies::optional(array(
+            'PEAR.php',
+        ));
+
+        $this->assertTrue(class_exists('PEAR'));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessageRegex /File not found.*DoesNotExist/
+     **/
+    public function testIncludePathNotFound()
+    {
+        Dependencies::required(array(
+            'DoesNotExist.php',
+        ));
+    }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the Fedora Autoloader package.
+ *
+ * (c) Shawn Iwinski <shawn@iwin.ski> and Remi Collet <remi@fedoraproject.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Fedora\Autoloader\Test;
+
+use PHPUnit\Framework\TestCase;
+use Fedora\Autoloader\Dependencies;
+
+class FunctionsTest extends TestCase
+{
+    public function dataPath()
+    {
+        if (DIRECTORY_SEPARATOR == '/') {
+            return array(
+                array(true,  '/tmp',         'Linux full path'),
+                array(false, 'foo/bar',      'Relative path'),
+            );
+        } else {
+            return array(
+                array(true,  'c:/tmp',       'Windows full path'),
+                array(true,  '//foo/bar',    'UNC'),
+                array(true,  '\\\\foo\\bar', 'UNC'),
+                array(false, 'foo/bar',      'Relative path'),
+            );
+        }
+    }
+
+    /**
+     * @dataProvider dataPath
+     **/
+    public function testIsFullPath($full, $path, $msg)
+    {
+        if ($full) {
+            $this->assertTrue(\Fedora\Autoloader\isFullPath($path), $msg);
+        } else {
+            $this->assertFalse(\Fedora\Autoloader\isFullPath($path), $msg);
+        }
+    }
+}


### PR DESCRIPTION
While full path is the recommended way, this could be used in case include_path should be used (PHPUnit and its dependencies)