### PR TITLE
Fix Travis, remove php:nightly and hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,25 @@
 language: php
 
-php:
-    - '5.3'
-    - '5.4'
-    - '5.5'
-    - '5.6'
-    - '7.0'
-    - '7.1'
-    - nightly
-    - hhvm
+jobs:
+    include:
+        - php: 5.3
+          dist: precise
+        - php: 5.4
+          dist: trusty
+        - php: 5.5
+          dist: trusty
+        - php: 5.6
+          dist: xenial
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+        - php: 7.3
+        - php: 7.4
 
-before_script:
-    - composer self-update
+before_install:
     - composer remove --dev friendsofphp/php-cs-fixer
+
+install:
     - composer install --no-interaction
 
 script: composer test


### PR DESCRIPTION
* Add `dist`s where required
* Remove php:nightly b/c it is PHP 8 which PHPUnit does not allow at this time even in latest release ([8.5.2](https://github.com/sebastianbergmann/phpunit/blob/8.5.2/composer.json#L24))
* Remove HHVM

@remicollet please review, merge, and then merge into #19 branch