### PR TITLE
Allow PHPUnit 7 and 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .php_cs.cache
+.phpunit.result.cache
 composer.lock
 /vendor/
 /phpcov/

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
-        "phpdocumentor/phpdocumentor": "*",
-        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.0.5",
+        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.0.5 || ^7 || ^8",
         "theseer/autoload": "^1.22"
     },
     "autoload": {

--- a/tests/DependenciesTest.php
+++ b/tests/DependenciesTest.php
@@ -106,9 +106,13 @@ class DependenciesTest extends TestCase
         $this->assertTrue(class_exists('Foo\\Bar\\Baz'));
     }
 
+    /**
+     * Just testing that no error/exception is thrown here
+     */
     public function testOptionalNotExists()
     {
         Dependencies::optional(array(__DIR__.'/fixtures/DoesNotExist.php'));
+        $this->assertTrue(true);
     }
 
     public function testOptionalFirstExists()


### PR DESCRIPTION
Note: Removed `phpdocumentor/phpdocumentor` dev dependency b/c it was causing install errors and we do not generate API docs anyway

I will merge #20 changes into this branch for passing CI when that pull request is merged