### PR TITLE
Fix for PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
-        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.0.5 || ^7 || ^8",
+        "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.0.5 || ^7 || ^8 || ^9",
         "theseer/autoload": "^1.22"
     },
     "autoload": {

--- a/tests/DependenciesTest.php
+++ b/tests/DependenciesTest.php
@@ -34,6 +34,10 @@ class DependenciesTest extends TestCase
      **/
     public function testRequiredNotExistsLast()
     {
+        if (method_exists($this, 'expectExceptionMessageMatches')) { /* for PHPUnit 9+ */
+            $this->expectException('RuntimeException');
+            $this->expectExceptionMessageMatches('/Files not found.*DoesNotExist.*AlsoNotExist/');
+        }
         Dependencies::required(array(
             array(
                 __DIR__.'/fixtures/DoesNotExist.php',
@@ -48,6 +52,10 @@ class DependenciesTest extends TestCase
      **/
     public function testRequiredNotExists()
     {
+        if (method_exists($this, 'expectExceptionMessageMatches')) { /* for PHPUnit 9+ */
+            $this->expectException('RuntimeException');
+            $this->expectExceptionMessageMatches('/File not found.*DoesNotExist/');
+        }
         Dependencies::required(array(
             __DIR__.'/fixtures/DoesNotExist.php',
         ));
@@ -174,6 +182,10 @@ class DependenciesTest extends TestCase
      **/
     public function testIncludePathNotFound()
     {
+        if (method_exists($this, 'expectExceptionMessageMatches')) { /* for PHPUnit 9+ */
+            $this->expectException('RuntimeException');
+            $this->expectExceptionMessageMatches('/File not found.*DoesNotExist/');
+        }
         Dependencies::required(array(
             'DoesNotExist.php',
         ));


### PR DESCRIPTION
Using latest PHPUnit and PHP 8.0.0beta3

```
$ php80 /usr/bin/phpunit9 --verbose
PHPUnit 9.3.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.0beta3
Configuration: /work/GIT/fedora-autoloader/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

.........................                                         25 / 25 (100%)

Time: 00:01.417, Memory: 4.00 MB

OK (25 tests, 68 assertions)

```

Only deprecation notice raise by PHPUnit8, but not a blocker, and old annotations are needed for old PHPUnit

`The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.`